### PR TITLE
Create config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,5 @@
+{
+
+    "fname": "/network/lustre/iss01/home/saeed.zahran/mne_data/MNE-sample-data/MEG/sample/sample_audvis_raw.fif",
+    "include": "['D101', 'D102', 'D103']"
+}

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
 
-    "egi": "/network/lustre/iss01/home/saeed.zahran/mne_data/MNE-sample-data/MEG/sample/sample_audvis_raw.fif",
+    "egi": "Latinus/S01/GAZE_S01 20120309 1622001.raw",
     "include": "'D101', 'D102', 'D103'"
 }

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
 
-    "fname": "/network/lustre/iss01/home/saeed.zahran/mne_data/MNE-sample-data/MEG/sample/sample_audvis_raw.fif",
-    "include": "['D101', 'D102', 'D103']"
+    "egi": "/network/lustre/iss01/home/saeed.zahran/mne_data/MNE-sample-data/MEG/sample/sample_audvis_raw.fif",
+    "include": "'D101', 'D102', 'D103'"
 }


### PR DESCRIPTION
Have an "include" param in the config file to allow the user to select which stimulus channels (or codes) they would like to include in MNE. The rest of the stimulus codes will be assumed irrelevant and not be included in the computation of STI014, which is the MNE way of coding for various events.